### PR TITLE
leveleditor: Make DNAGroups instead of DNANodes

### DIFF
--- a/toontown/leveleditor/LevelEditor.py
+++ b/toontown/leveleditor/LevelEditor.py
@@ -466,7 +466,7 @@ class LevelEditor(NodePath, DirectObject):
 
         # Create new toplevel node path and DNA
         if fCreateToplevel:
-            self.createToplevel(DNANode('level'))
+            self.createToplevel(DNAGroup('level'))
 
         # Initialize variables
         # Reset grid
@@ -1631,7 +1631,7 @@ class LevelEditor(NodePath, DirectObject):
         """ Create a new DNA Node group under the active parent """
         # Create a new DNA Node group
         if type == 'dna':
-            newDNANode = DNANode('group_' + repr(self.getGroupNum()))
+            newDNANode = DNAGroup('group_' + repr(self.getGroupNum()))
         else:
             newDNANode = DNAVisGroup('VisGroup_' + repr(self.getGroupNum()))
             # Increment group counter


### PR DESCRIPTION
If you look at the .dna files inside Disney's phases, you would notice that they all mostly have a DNAGroup as top level instead of DNANode.  

DNANode nodes will output:
```
node [
]
```
while DNAGroup instead outputs:
```
group [
]
```

Assuming that DNANode has been obsoleted in favor of DNAGroup, this PR ensures it'll follow the same format as Disney's.