### PR TITLE
leveleditor: A couple new feautres

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ __pycache__/
 *.pyd
 *$py.class
 phase_*/
+hoods/
+leveleditor/stylefiles
 
 # C extensions
 *.so

--- a/toontown/leveleditor/LevelEditor.py
+++ b/toontown/leveleditor/LevelEditor.py
@@ -97,8 +97,10 @@ except NameError:
     loadDNAFile(DNASTORE, 'dna/storage.dna', CSDefault, 1)
     loadDNAFile(DNASTORE, 'phase_4/dna/storage.dna', CSDefault, 1)
     loadDNAFile(DNASTORE, 'phase_5/dna/storage_town.dna', CSDefault, 1)
+
     # loadDNAFile(DNASTORE, 'phase_5.5/dna/storage_estate.dna', CSDefault, 1)
     # loadDNAFile(DNASTORE, 'phase_5.5/dna/storage_house_interior.dna', CSDefault, 1)
+
     # Load all the neighborhood specific storage files
     if 'TT' in base.hoods:
         loadDNAFile(DNASTORE, 'phase_4/dna/storage_TT.dna', CSDefault, 1)
@@ -150,6 +152,13 @@ except NameError:
     if 'TUT' in base.hoods:
         loadDNAFile(DNASTORE, 'phase_3.5/dna/storage_tutorial.dna', CSDefault, 1)
         loadDNAFile(DNASTORE, 'phase_3.5/dna/storage_interior.dna', CSDefault, 1)
+
+    # Load storage files for custom hoods
+    if base.customHoods:
+        for data in base.customHoods:
+            paths = data.get(LevelEditorGlobals.CUSTOM_HOOD_PATH)
+            for path in paths:
+                loadDNAFile(DNASTORE, path, CSDefault, 1)
 
     DNASTORE.storeFont('humanist', ToontownGlobals.getInterfaceFont())
     DNASTORE.storeFont('mickey', ToontownGlobals.getSignFont())

--- a/toontown/leveleditor/LevelEditorGlobals.py
+++ b/toontown/leveleditor/LevelEditorGlobals.py
@@ -1,6 +1,21 @@
 import string
 from pandac.PandaModules import *
 
+# Valid Toontown projects
+TOONTOWN_ONLINE = 0
+TOONTOWN_REWRITTEN = 1
+TOONTOWN_CORPORATE_CLASH = 2
+TOONTOWN_OFFLINE = 3
+
+SERVER_TO_ID = {'online': TOONTOWN_ONLINE,
+                'rewritten': TOONTOWN_REWRITTEN,
+                'clash': TOONTOWN_CORPORATE_CLASH,
+                'offline': TOONTOWN_OFFLINE}
+
+CUSTOM_HOOD_NAME_SHORTHAND = 'name_shorthand'
+CUSTOM_HOOD_NAME_LONGHAND = 'name_longhand'
+CUSTOM_HOOD_PATH = 'storage_files'
+
 hoodString = 'TT DD DL'
 # hoodString = base.config.GetString('level-editor-hoods',
 #                                       'TT DD BR DG DL MM CC CL CM CS GS GZ OZ PA')
@@ -22,8 +37,12 @@ HOOD_IDS = {'TT': 'toontown_central',
             'GZ': 'golf_zone',
             'PA': 'party_zone',
             'ES': 'estate',
-            'TUT': 'tutorial'
-            }
+            'TUT': 'tutorial'}
+
+for hood in base.customHoods:
+    shorthand = hood.get(CUSTOM_HOOD_NAME_SHORTHAND)
+    longhand = hood.get(CUSTOM_HOOD_NAME_LONGHAND)
+    HOOD_IDS[shorthand] = longhand
 
 # Init neighborhood arrays
 NEIGHBORHOODS = []
@@ -59,7 +78,7 @@ BUILDING_HEIGHTS = [10, 14, 20, 24, 25, 30]
 NUM_WALLS = [1, 2, 3]
 LANDMARK_SPECIAL_TYPES = ['', 'hq', 'gagshop', 'clotheshop', 'petshop', 'kartshop']
 # Corporate Clash has an UNCAPTURABLE building type to flag uncapturable buildings
-if ConfigVariableBool("want-clash-specific-options", False): 
+if base.server == TOONTOWN_CORPORATE_CLASH:
     LANDMARK_SPECIAL_TYPES.append('uncapturable')
 
 OBJECT_SNAP_POINTS = {

--- a/ttle.py
+++ b/ttle.py
@@ -1,18 +1,52 @@
 """ ToontownLevelEditor 2.0 Base Class  - Drewcification 091420 """
 
+from direct.directnotify.DirectNotifyGlobal import directNotify
+from direct.showbase.ShowBase import ShowBase
+
+from panda3d.core import loadPrcFile, loadPrcFileData
+
+from tkinter import Tk, messagebox
+
 import asyncio
 import argparse
 import builtins
-import webbrowser
+import json
+import os
 import sys
-from direct.directnotify.DirectNotifyGlobal import directNotify
-from direct.showbase.ShowBase import ShowBase
-from panda3d.core import loadPrcFile, loadPrcFileData
-from tkinter import Tk, messagebox
+import webbrowser
+
+TOONTOWN_ONLINE = 0
+TOONTOWN_REWRITTEN = 1
+TOONTOWN_CORPORATE_CLASH = 2
+TOONTOWN_OFFLINE = 3
+
+SERVER_TO_ID = {'online': TOONTOWN_ONLINE,
+                'rewritten': TOONTOWN_REWRITTEN,
+                'clash': TOONTOWN_CORPORATE_CLASH,
+                'offline': TOONTOWN_OFFLINE}
+
+# Sample custom hood
+customHoodSample = '''{
+ "name_shorthand": "TT",
+ "name_longhand": "toontown_central",
+ "storage_files": ["phase_4/dna/storage_TT.dna", "phase_4/dna/storage_TT_sz.dna", "phase_5/dna/storage_TT_town.dna"]
+ }'''
+
+# Make custom hood directory if it doesn't exist
+if not os.path.exists('hoods/'):
+    os.mkdir('hoods/')
+
+# Create sample custom hood if it doesn't exist
+if not os.path.isfile('hoods/sample.json'):
+    with open('hoods/sample.json', 'w') as data:
+        data.write(customHoodSample)
+        data.close()
+
 
 class ToontownLevelEditor(ShowBase):
     notify = directNotify.newCategory("Open Level Editor")
     APP_VERSION = open('ver', 'r').read()
+
     def __init__(self):
 
         # Load the prc file prior to launching showbase in order
@@ -23,8 +57,8 @@ class ToontownLevelEditor(ShowBase):
         parser = argparse.ArgumentParser(description="Modes")
         parser.add_argument("--experimental", action='store_true', help="Enables experimental features")
         parser.add_argument("--debug", action='store_true', help="Enables debugging features")
-        parser.add_argument("--clash", action='store_true', help="Enables Corporate Clash features")
         parser.add_argument("--noupdate", action='store_true', help="Disables Auto Updating")
+        parser.add_argument("--server", nargs="*", help="Enables features exclusive to various Toontown projects", default='online')
         parser.add_argument("--hoods", nargs="*", help="Only loads the storage files of the specified hoods",
                             default=['TT', 'DD', 'BR', 'DG',
                                      'DL', 'MM', 'CC', 'CL',
@@ -37,8 +71,10 @@ class ToontownLevelEditor(ShowBase):
             loadPrcFileData("", "want-experimental true")
         if args.debug:
             loadPrcFileData("", "want-debug true")
-        if args.clash:
-            loadPrcFileData("", "want-clash-specific-options true")
+
+        server = SERVER_TO_ID.get(args.server[0].lower(), TOONTOWN_ONLINE)
+        self.server = server
+
         self.hoods = args.hoods
         # HACK: Check for dnaPath in args.hoods
         for hood in self.hoods[:]:
@@ -47,11 +83,25 @@ class ToontownLevelEditor(ShowBase):
                 args.hoods.remove(hood)
                 break
 
+        # Let's do our custom hood loading now
+        self.customHoods = []
+
+        if os.path.exists('./hoods'):
+            # Iterate over all files in the hoods folder
+            files = os.listdir('./hoods')
+            for fileName in files:
+                # Don't include our sample json, and make sure to only include json to begin with
+                if fileName != 'sample.json' and fileName[-5:] == '.json':
+                    with open('hoods/{}'.format(fileName)) as info:
+                        hood = json.load(info)
+                        shorthand = hood.get('name_shorthand')
+                        self.hoods.append(shorthand)
+                        self.customHoods.append(hood)
+
         # Import the main dlls so we don't have to repeatedly import them everywhere
         builtins.__dict__.update(__import__('panda3d.core', fromlist=['*']).__dict__)
         builtins.__dict__.update(__import__('libotp', fromlist=['*']).__dict__)
         builtins.__dict__.update(__import__('libtoontown', fromlist=['*']).__dict__)
-
 
         tkroot = Tk()
         tkroot.withdraw()


### PR DESCRIPTION
Replaced the --clash launch option with --server. This will pave the way for future updates to the level editor that are tailored for specific Toontown games. Right now, there are four modes: "online", "rewritten", "clash", and "offline". Only Clash has a difference at this time.

Added a custom hoods feature. Look at the sample.json file in the hoods folder for a demo on how to create a custom hood. Custom hoods will be loaded automatically when their .json file is present in the hoods folder.

Note: Feel free to change some of the logic regarding how these are loaded. Right now, simply having a custom hood in your hoods folder will automatically load it upon boot of the level editor. I decided to go this route instead of having you to additionally specify that you wanted to load your custom hood. I'm indifferent either way, I just think this is more convenient.