### PR TITLE
leveleditor: Fix a crash when cancelling out window count changes.

### DIFF
--- a/toontown/leveleditor/LevelEditor.py
+++ b/toontown/leveleditor/LevelEditor.py
@@ -1819,6 +1819,7 @@ class LevelEditor(NodePath, DirectObject):
 
     def removeWindows(self, windows, parent):
         # And record number of windows
+        self.setCurrent('window_texture', windows.getCode())
         self.setCurrent('window_color', windows.getColor())
         self.setCurrent('window_count', windows.getWindowCount())
         DNARemoveChildOfClass(parent, DNA_WINDOWS)


### PR DESCRIPTION
This fixes a crash and addresses issue #5 when you change your window count to 0 and then cancel the operation.