### PR TITLE
imgui: Restore showing DNA type names on Scene Graph Explorer

### DIFF
--- a/toontown/panels/SceneGraphExplorer.py
+++ b/toontown/panels/SceneGraphExplorer.py
@@ -47,6 +47,13 @@ class SceneGraphExplorer(DirectObject):
             typeName = nodePath.node().getType().getName()
             name = nodePath.getName()
 
+            dnaNode = None
+            if hasattr(base, 'le'):
+                dnaNode = base.le.findDNANode(nodePath)
+            if dnaNode is not None:
+                typeName = dnaNode.getType().getName()
+                name = dnaNode.getName()
+
             tree = imgui.tree_node_ex(f"{self.nodePath.getName()}-{id}", flags, f"{typeName} {name}")
 
             if self.flashOnClick and imgui.is_item_clicked():


### PR DESCRIPTION
Restores original Tkinter explorer behavior.
<img width="411" height="768" alt="image" src="https://github.com/user-attachments/assets/5ed27c13-8497-4e4f-aa0e-feee5fdb0e99" />
